### PR TITLE
GAS-95: Add passlib into requirements.txt for building Ansible

### DIFF
--- a/scripts/ansible/install.sh
+++ b/scripts/ansible/install.sh
@@ -17,6 +17,7 @@ cat <<EOS > "${REQUIREMENTS}"
 ansible==${ANSIBLE}
 jmespath
 dnspython
+passlib
 EOS
 
 "/usr/bin/python${VERSION}" -m venv --clear /app/venv


### PR DESCRIPTION
Currently `ansible` PEX build cannot hash passwords into `blowfish` hash. Adding `passlib` to its `requirements.txt` solves the issue

Ref: https://github.com/ansible/ansible/issues/77808 affects `2.9 core`